### PR TITLE
fix: persistLocally with different versions

### DIFF
--- a/src/services/utils/persistLocally.ts
+++ b/src/services/utils/persistLocally.ts
@@ -1,5 +1,16 @@
 import { Observable } from "rxjs"
 
+const VERSION_KEY = "@smoldot-ads/schema-version"
+const CURRENT_VERSION = 1
+
+if (typeof window !== "undefined") {
+  const version = Number(window.localStorage.getItem(VERSION_KEY))
+  if (version !== CURRENT_VERSION) {
+    window.localStorage.clear()
+    window.localStorage.setItem(VERSION_KEY, CURRENT_VERSION.toString(10))
+  }
+}
+
 export const persistLocally =
   (key: string) =>
   <T>(source: Observable<T>) =>


### PR DESCRIPTION
Yesterday after @wirednkod pulled the latest changes from the repo, he was getting a weird error after running `npm start`. The error went away after clearing his localStorage. What happened was that the data that was persisted in localStorage in previous versions was not compatible with the data that was being stored in the latest version of the code. That's because as we keep developing, we keep refining the schema of the DTOs that we want to work with.

In order to avoid these pains (while we are still in the initial development phase) I thought that what we can do is this: any time that we make a breaking change on the interfaces that are being persisted we increase the version number of the `CURRENT_VERSION` constant that's located under the `persistLocally` util, that will create a mismatch between the current version that's on localStorage, therefore signaling that the storage needs to be cleared.

Again, this is meant to be a temporary solution while we are still in the initial development phase.